### PR TITLE
Update ext-calendar-utils.jsm

### DIFF
--- a/calendar/experiments/calendar/ext-calendar-utils.jsm
+++ b/calendar/experiments/calendar/ext-calendar-utils.jsm
@@ -174,6 +174,8 @@ function convertItem(item, options, extension) {
   props.description = item.getProperty("description") || "";
   props.location = item.getProperty("location") || "";
   props.categories = item.getCategories();
+  props.startDate = item.startDate ? item.startDate.icalString : "";
+  props.endDate = item.endDate ? item.endDate.icalString : "";
 
   if (isOwnCalendar(item.calendar, extension)) {
     props.metadata = {};


### PR DESCRIPTION
The experimental API allows accessing the Lightning calendar inside Thunderbird and makes available the properties of the events for the calendar ( calendarId, description, id, location, title) but NOT the startdate and enddate property for each event.  This is useful for addons which fetch events and display/parse them.