### PR TITLE
Update calendar experiment to Thunderbird 128

### DIFF
--- a/calendar/README.md
+++ b/calendar/README.md
@@ -12,5 +12,5 @@ reliable API documentation please see the relevant [schema files](./schema/).
 | ------------- | --------
 | Description   | Experiment and add-on for calendar-related APIs in Thunderbird.
 | Status        | Draft
-| Compatibility | Thunderbird 91 (possibly Thunderbird 78)
+| Compatibility | Thunderbird 128
 | Tracking      | [bug 1627205](https://bugzilla.mozilla.org/show_bug.cgi?id=1627205)

--- a/calendar/experiments/calendar/child/ext-calendar-provider-actor.sys.mjs
+++ b/calendar/experiments/calendar/child/ext-calendar-provider-actor.sys.mjs
@@ -2,12 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-var EXPORTED_SYMBOLS = ["CalendarProviderChild"];
-
-class CalendarProviderChild extends JSWindowActorChild {
+export class CalendarProviderChild extends JSWindowActorChild {
   receiveMessage(msg) {
     if (msg.name == "postMessage") {
-      this.contentWindow.postMessage(msg.data.message, msg.data.origin)
+      this.contentWindow.postMessage(msg.data.message, msg.data.origin);
     }
   }
 }

--- a/calendar/experiments/calendar/ext-calendar-utils.sys.mjs
+++ b/calendar/experiments/calendar/ext-calendar-utils.sys.mjs
@@ -2,52 +2,22 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-var EXPORTED_SYMBOLS = [
-  "isOwnCalendar",
-  "unwrapCalendar",
-  "getResolvedCalendarById",
-  "getCachedCalendar",
-  "isCachedCalendar",
-  "convertCalendar",
-  "propsToItem",
-  "convertItem",
-  "convertAlarm",
-  "setupE10sBrowser",
-];
+var {
+  ExtensionUtils: { ExtensionError, promiseEvent }
+} = ChromeUtils.importESModule("resource://gre/modules/ExtensionUtils.sys.mjs");
 
-var { XPCOMUtils } = ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
+var { cal } = ChromeUtils.importESModule("resource:///modules/calendar/calUtils.sys.mjs");
+var { CalEvent } = ChromeUtils.importESModule("resource:///modules/CalEvent.sys.mjs");
+var { CalTodo } = ChromeUtils.importESModule("resource:///modules/CalTodo.sys.mjs");
+var { ExtensionParent } = ChromeUtils.importESModule("resource://gre/modules/ExtensionParent.sys.mjs");
 
-XPCOMUtils.defineLazyModuleGetters(this, {
-  cal: "resource:///modules/calendar/calUtils.jsm",
-  ICAL: "resource:///modules/calendar/Ical.jsm",
-  CalEvent: "resource:///modules/CalEvent.jsm",
-  CalTodo: "resource:///modules/CalTodo.jsm",
-  ExtensionParent: "resource://gre/modules/ExtensionParent.jsm",
-});
+var { default: ICAL } = ChromeUtils.importESModule("resource:///modules/calendar/Ical.sys.mjs");
 
-var { ExtensionError, promiseEvent } = ChromeUtils.import(
-  "resource://gre/modules/ExtensionUtils.jsm"
-).ExtensionUtils;
-
-XPCOMUtils.defineLazyGetter(this, "standaloneStylesheets", () => {
-  let stylesheets = [];
-  let { AppConstants } = ChromeUtils.import("resource://gre/modules/AppConstants.jsm");
-
-  if (AppConstants.platform === "macosx") {
-    stylesheets.push("chrome://browser/content/extension-mac-panel.css");
-  } else if (AppConstants.platform === "win") {
-    stylesheets.push("chrome://browser/content/extension-win-panel.css");
-  } else if (AppConstants.platform === "linux") {
-    stylesheets.push("chrome://browser/content/extension-linux-panel.css");
-  }
-  return stylesheets;
-});
-
-function isOwnCalendar(calendar, extension) {
+export function isOwnCalendar(calendar, extension) {
   return calendar.superCalendar.type == "ext-" + extension.id;
 }
 
-function unwrapCalendar(calendar) {
+export function unwrapCalendar(calendar) {
   let unwrapped = calendar.wrappedJSObject;
 
   if (unwrapped.mUncachedCalendar) {
@@ -57,7 +27,7 @@ function unwrapCalendar(calendar) {
   return unwrapped;
 }
 
-function getResolvedCalendarById(extension, id) {
+export function getResolvedCalendarById(extension, id) {
   let calendar;
   if (id.endsWith("#cache")) {
     let cached = cal.manager.getCalendarById(id.substring(0, id.length - 6));
@@ -72,16 +42,16 @@ function getResolvedCalendarById(extension, id) {
   return calendar;
 }
 
-function getCachedCalendar(calendar) {
+export function getCachedCalendar(calendar) {
   return calendar.wrappedJSObject.mCachedCalendar || calendar;
 }
 
-function isCachedCalendar(id) {
+export function isCachedCalendar(id) {
   // TODO make this better
   return id.endsWith("#cache");
 }
 
-function convertCalendar(extension, calendar) {
+export function convertCalendar(extension, calendar) {
   if (!calendar) {
     return null;
   }
@@ -105,7 +75,7 @@ function convertCalendar(extension, calendar) {
   return props;
 }
 
-function propsToItem(props, baseItem) {
+export function propsToItem(props, baseItem) {
   let item;
   if (baseItem) {
     item = baseItem;
@@ -122,7 +92,18 @@ function propsToItem(props, baseItem) {
   if (props.formats?.use == "ical") {
     item.icalString = props.formats.ical;
   } else if (props.formats?.use == "jcal") {
-    item.icalString = ICAL.stringify(props.formats.jcal);
+    try {
+      item.icalString = ICAL.stringify(props.formats.jcal);
+    } catch (e) {
+      let jsonstring;
+      try {
+        jsonstring = JSON.stringify(props.formats.jcal, null, 2);
+      } catch {
+        jsonstring = props.formats.jcal;
+      }
+
+      throw new ExtensionError("Could not parse jCal: " + e + "\n" + jsonstring);
+    }
   } else {
     if (props.id) {
       item.id = props.id;
@@ -155,7 +136,7 @@ function propsToItem(props, baseItem) {
   return item;
 }
 
-function convertItem(item, options, extension) {
+export function convertItem(item, options, extension) {
   if (!item) {
     return null;
   }
@@ -181,7 +162,7 @@ function convertItem(item, options, extension) {
     try {
       // TODO This is a sync operation. Not great. Can we optimize this?
       props.metadata = JSON.parse(cache.getMetaData(item.id)) ?? {};
-    } catch (e) {
+    } catch {
       // Ignore json parse errors
     }
   }
@@ -218,7 +199,7 @@ function convertItem(item, options, extension) {
   return props;
 }
 
-function convertAlarm(item, alarm) {
+export function convertAlarm(item, alarm) {
   const ALARM_RELATED_MAP = {
     [Ci.calIAlarm.ALARM_RELATED_ABSOLUTE]: "absolute",
     [Ci.calIAlarm.ALARM_RELATED_START]: "start",
@@ -234,7 +215,7 @@ function convertAlarm(item, alarm) {
   };
 }
 
-async function setupE10sBrowser(extension, browser, parent, initOptions={}) {
+export async function setupE10sBrowser(extension, browser, parent, initOptions={}) {
   browser.setAttribute("type", "content");
   browser.setAttribute("disableglobalhistory", "true");
   browser.setAttribute("messagemanagergroup", "webext-browsers");
@@ -267,9 +248,10 @@ async function setupE10sBrowser(extension, browser, parent, initOptions={}) {
   let sheets = [];
   if (initOptions.browser_style) {
     delete initOptions.browser_style;
-    sheets.push(...ExtensionParent.extensionStylesheets);
+    sheets.push("chrome://browser/content/extension.css");
   }
-  sheets.push(...standaloneStylesheets);
+  sheets.push("chrome://browser/content/extension-popup-panel.css");
+
 
   const initBrowser = () => {
     ExtensionParent.apiManager.emit("extension-browser-inserted", browser);

--- a/calendar/experiments/calendar/parent/ext-calendarItemAction.js
+++ b/calendar/experiments/calendar/parent/ext-calendarItemAction.js
@@ -2,29 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-ChromeUtils.defineModuleGetter(
-  this,
-  "ToolbarButtonAPI",
-  "resource:///modules/ExtensionToolbarButtons.jsm"
-);
-ChromeUtils.defineModuleGetter(
-  this,
-  "ExtensionParent",
-  "resource://gre/modules/ExtensionParent.jsm"
-);
+var { ExtensionCommon: { makeWidgetId } } = ChromeUtils.importESModule("resource://gre/modules/ExtensionCommon.sys.mjs");
 
-ChromeUtils.defineModuleGetter(
-  this,
-  "ExtensionSupport",
-  "resource:///modules/ExtensionSupport.jsm",
-);
-
-
-var { ExtensionCommon } = ChromeUtils.import(
-  "resource://gre/modules/ExtensionCommon.jsm"
-);
-
-var { makeWidgetId } = ExtensionCommon;
+var { ExtensionParent } = ChromeUtils.importESModule("resource://gre/modules/ExtensionParent.sys.mjs");
+var { ExtensionSupport } = ChromeUtils.importESModule("resource:///modules/ExtensionSupport.sys.mjs");
+var { ToolbarButtonAPI } = ChromeUtils.importESModule("resource:///modules/ExtensionToolbarButtons.sys.mjs");
 
 const calendarItemActionMap = new WeakMap();
 

--- a/calendar/experiments/calendar/parent/ext-calendarItemDetails.js
+++ b/calendar/experiments/calendar/parent/ext-calendarItemDetails.js
@@ -2,115 +2,27 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-ChromeUtils.defineModuleGetter(
-  this,
-  "ExtensionSupport",
-  "resource:///modules/ExtensionSupport.jsm",
-);
+var {
+  ExtensionCommon: { ExtensionAPI, makeWidgetId }
+} = ChromeUtils.importESModule("resource://gre/modules/ExtensionCommon.sys.mjs");
 
-var { XPCOMUtils } = ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
-var { ExtensionCommon } = ChromeUtils.import("resource://gre/modules/ExtensionCommon.jsm");
-var { ExtensionUtils } = ChromeUtils.import("resource://gre/modules/ExtensionUtils.jsm");
-
-var { promiseEvent } = ExtensionUtils;
-var { makeWidgetId, ExtensionAPI } = ExtensionCommon;
-
-
-XPCOMUtils.defineLazyGetter(this, "standaloneStylesheets", () => {
-  let stylesheets = [];
-  let { AppConstants } = ChromeUtils.import("resource://gre/modules/AppConstants.jsm");
-
-  if (AppConstants.platform === "macosx") {
-    stylesheets.push("chrome://browser/content/extension-mac-panel.css");
-  } else if (AppConstants.platform === "win") {
-    stylesheets.push("chrome://browser/content/extension-win-panel.css");
-  } else if (AppConstants.platform === "linux") {
-    stylesheets.push("chrome://browser/content/extension-linux-panel.css");
-  }
-  return stylesheets;
-});
-
+var { ExtensionSupport } = ChromeUtils.importESModule("resource:///modules/ExtensionSupport.sys.mjs");
 
 this.calendarItemDetails = class extends ExtensionAPI {
-  async _attachBrowser(tabpanel) {
-    let document = tabpanel.ownerDocument;
-    let browser = document.createXULElement("browser");
-    browser.setAttribute("flex", "1");
-    browser.setAttribute("type", "content");
-    browser.setAttribute("disableglobalhistory", "true");
-    browser.setAttribute("messagemanagergroup", "webext-browsers");
-    browser.setAttribute("transparent", "true");
-    browser.setAttribute("class", "webextension-popup-browser");
-    browser.setAttribute("webextension-view-type", "subview");
-
-    // Ensure the browser will initially load in the same group as other browsers from the same
-    // extension.
-    browser.setAttribute(
-      "initialBrowsingContextGroupId",
-      this.extension.policy.browsingContextGroupId
-    );
-
-    if (this.extension.remote) {
-      browser.setAttribute("remote", "true");
-      browser.setAttribute("remoteType", this.extension.remoteType);
-      browser.setAttribute("maychangeremoteness", "true");
-    }
-
-    let readyPromise;
-    if (this.extension.remote) {
-      readyPromise = promiseEvent(browser, "XULFrameLoaderCreated");
-    } else {
-      readyPromise = promiseEvent(browser, "load");
-    }
-
-    tabpanel.appendChild(browser);
-
-    if (!this.extension.remote) {
-      // FIXME: bug 1494029 - this code used to rely on the browser binding
-      // accessing browser.contentWindow. This is a stopgap to continue doing
-      // that, but we should get rid of it in the long term.
-      browser.contentwindow; // eslint-disable-line no-unused-expressions
-    }
-
-    let sheets = [];
-    if (this.extension.manifest.calendar_item_details.browser_style) {
-      sheets.push(...ExtensionParent.extensionStylesheets);
-    }
-    sheets.push(...standaloneStylesheets);
-
-
-    const initBrowser = () => {
-      ExtensionParent.apiManager.emit("extension-browser-inserted", browser);
-      let mm = browser.messageManager;
-      mm.loadFrameScript(
-        "chrome://extensions/content/ext-browser-content.js",
-        false,
-        true
-      );
-
-      mm.sendAsyncMessage("Extension:InitBrowser", {
-        allowScriptsToClose: true,
-        blockParser: false,
-        maxWidth: 800,
-        maxHeight: 600,
-        stylesheets: sheets
-      });
-    };
-    browser.addEventListener("DidChangeBrowserRemoteness", initBrowser);
-
-    return readyPromise.then(() => {
-      initBrowser();
-      browser.loadURI(this.extension.manifest.calendar_item_details.default_content, { triggeringPrincipal: this.extension.principal });
-    });
-  }
-
   onLoadCalendarItemPanel(window, origLoadCalendarItemPanel, iframeId, url) {
+    const { setupE10sBrowser } = ChromeUtils.importESModule("resource://tb-experiments-calendar/experiments/calendar/ext-calendar-utils.sys.mjs");
+
     let res = origLoadCalendarItemPanel(iframeId, url);
     if (this.extension.manifest.calendar_item_details) {
-      let panelFrame = window.document.getElementById(iframeId || "calendar-item-panel-iframe");
+      let panelFrame;
+      if (window.tabmail) {
+        panelFrame = window.document.getElementById(iframeId|| tabmail.currentTabInfo.iframe?.id);
+      } else {
+        panelFrame = window.document.getElementById("calendar-item-panel-iframe");
+      }
+
       panelFrame.contentWindow.addEventListener("load", (event) => {
         let document = event.target.ownerGlobal.document;
-        console.log(this.extension.manifest.calendar_item_details);
 
         let widgetId = makeWidgetId(this.extension.id);
 
@@ -128,7 +40,15 @@ this.calendarItemDetails = class extends ExtensionAPI {
         tabpanel.setAttribute("id", widgetId + "-calendarItemDetails-tabpanel");
         tabpanel.setAttribute("flex", "1");
 
-        this._attachBrowser(tabpanel);
+        let browser = document.createXULElement("browser");
+        browser.setAttribute("flex", "1");
+        let loadPromise = setupE10sBrowser(this.extension, browser, tabpanel);
+
+        return loadPromise.then(() => {
+          browser.fixupAndLoadURIString(this.extension.manifest.calendar_item_details.default_content, {
+            triggeringPrincipal: this.extension.principal
+          });
+        });
       });
     }
 
@@ -158,13 +78,29 @@ this.calendarItemDetails = class extends ExtensionAPI {
         "chrome://calendar/content/calendar-event-dialog.xhtml"
       ],
       onLoadWindow: (window) => {
-        let orig = window.onLoadCalendarItemPanel;
-        window.onLoadCalendarItemPanel = this.onLoadCalendarItemPanel.bind(this, window, orig.bind(window));
+        if (window.location.href == "chrome://messenger/content/messenger.xhtml") {
+          let orig = window.onLoadCalendarItemPanel;
+          window.onLoadCalendarItemPanel = this.onLoadCalendarItemPanel.bind(this, window, orig.bind(window));
+          window._onLoadCalendarItemPanelOrig = orig;
+        } else {
+          window.setTimeout(() => {
+            this.onLoadCalendarItemPanel(window, () => {});
+          }, 0);
+        }
       }
     });
   }
   onShutdown() {
     ExtensionSupport.unregisterWindowListener("ext-calendarItemDetails-" + this.extension.id);
+
+    for (let wnd of ExtensionSupport.openWindows) {
+      if (wnd.location.href == "chrome://messenger/content/messenger.xhtml") {
+        if (wnd._onLoadCalendarItemPanelOrig) {
+          wnd.onLoadCalendarItemPanel = wnd._onLoadCalendarItemPanelOrig;
+          wnd._onLoadCalendarItemPanelOrig = null;
+        }
+      }
+    }
   }
   getAPI(context) {
     return { calendar: { itemDetails: {} } };

--- a/calendar/experiments/calendar/schema/calendar-calendars.json
+++ b/calendar/experiments/calendar/schema/calendar-calendars.json
@@ -151,7 +151,8 @@
               "readOnly": { "type": "boolean", "optional": true },
               "enabled": { "type": "boolean", "optional": true },
               "color": { "type": "string", "optional": true },
-              "capabilities": { "$ref": "CalendarCapabilities", "optional": true }
+              "capabilities": { "$ref": "CalendarCapabilities", "optional": true },
+              "lastError": { "type": "string", "optional": true }
             }
           }
         ]

--- a/calendar/experiments/calendar/schema/calendar-provider.json
+++ b/calendar/experiments/calendar/schema/calendar-provider.json
@@ -22,13 +22,41 @@
   },
   {
     "namespace": "calendar.provider",
+    "types": [{
+      "id": "ItemError",
+      "type": "object",
+      "description": "A failure in an onItem* handler",
+      "properties": {
+        "error": {
+          "type": "string",
+          "enum": [
+            "GENERAL_FAILURE",
+            "READ_FAILED",
+            "MODIFY_FAILED",
+            "CONFLICT"
+          ]
+        }
+      }
+    }, {
+      "id": "ItemOptions",
+      "type": "object",
+      "description": "Options for the create/modify/delete event handlers",
+      "properties": {
+        "force": {
+          "type": "boolean",
+          "description": "If true, instruct the provider to force overwrite changes (i.e. after a conflict)",
+          "optional": true
+        }
+      }
+    }],
     "events": [
       {
         "name": "onItemCreated",
         "type": "function",
         "parameters": [
           { "name": "calendar", "$ref": "calendar.calendars.Calendar" },
-          { "name": "item", "$ref": "calendar.items.CalendarItem" }
+          { "name": "item", "$ref": "calendar.items.CalendarItem" },
+          { "name": "options", "$ref": "calendar.provider.ItemOptions" }
         ],
         "extraParameters": [
           {
@@ -38,7 +66,14 @@
               "returnFormat": { "$ref": "calendar.items.ReturnFormat", "optional": true }
             }
           }
-        ]
+        ],
+        "returns": {
+          "description": "Returns the added item, or an error that occurred",
+          "choices": [
+            { "$ref": "calendar.provider.ItemError" },
+            { "$ref": "calendar.items.CalendarItem" }
+          ]
+        }
       },
       {
         "name": "onItemUpdated",
@@ -46,7 +81,8 @@
         "parameters": [
           { "name": "calendar", "$ref": "calendar.calendars.Calendar" },
           { "name": "item", "$ref": "calendar.items.CalendarItem" },
-          { "name": "oldItem", "$ref": "calendar.items.CalendarItem" }
+          { "name": "oldItem", "$ref": "calendar.items.CalendarItem" },
+          { "name": "options", "$ref": "calendar.provider.ItemOptions" }
         ],
         "extraParameters": [
           {
@@ -56,14 +92,22 @@
               "returnFormat": { "$ref": "calendar.items.ReturnFormat", "optional": true }
             }
           }
-        ]
+        ],
+        "returns": {
+          "description": "Returns the modified item, or an error that occurred",
+          "choices": [
+            { "$ref": "calendar.provider.ItemError" },
+            { "$ref": "calendar.items.CalendarItem" }
+          ]
+        }
       },
       {
         "name": "onItemRemoved",
         "type": "function",
         "parameters": [
           { "name": "calendar", "$ref": "calendar.calendars.Calendar" },
-          { "name": "item", "$ref": "calendar.items.CalendarItem" }
+          { "name": "item", "$ref": "calendar.items.CalendarItem" },
+          { "name": "options", "$ref": "calendar.provider.ItemOptions" }
         ],
         "extraParameters": [
           {
@@ -73,7 +117,12 @@
               "returnFormat": { "$ref": "calendar.items.ReturnFormat", "optional": true }
             }
           }
-        ]
+        ],
+        "returns": {
+          "description": "Optionally returns an item error if it occurred",
+          "optional": true,
+          "$ref": "calendar.provider.ItemError"
+        }
       },
       {
         "name": "onInit",

--- a/calendar/experiments/calendar/schema/calendarItemAction.json
+++ b/calendar/experiments/calendar/schema/calendarItemAction.json
@@ -50,6 +50,13 @@
                 "description": "Currently unused.",
                 "type": "string",
                 "optional": true
+              },
+              "type": {
+                "description": "Specifies the type of the button. Default type is <var>button</var>.",
+                "type": "string",
+                "enum": ["button", "menu"],
+                "optional": true,
+                "default": "button"
               }
             },
             "optional": true

--- a/calendar/manifest.json
+++ b/calendar/manifest.json
@@ -4,7 +4,7 @@
   "author": "Philipp Kewisch",
   "description": "Draft experiment for Thunderbird MailExtensions covering calendaring",
   "version": "2.2.0",
-  "applications": {
+  "browser_specific_settings": {
     "gecko": {
       "id": "ext-calendar-draft@mozilla.kewis.ch"
     }
@@ -44,7 +44,8 @@
   "calendar_item_action": {
     "default_icon": "addon.png",
     "default_popup": "content/calendar-item-action.html",
-    "default_title": "Calendar Item Action"
+    "default_title": "Calendar Item Action",
+    "type": "button"
   },
 
   "background": {


### PR DESCRIPTION
This updates the calendar experiment to 128 unless I missed something. It also adds some new features:

* A mechanism for handling conflicts and errors from the onItem* functions
* A new options parameter to the onItem* functions, which is used for indicating e.g. force overwrite. In the future it can also be used to indicate that an event addition is an invitation etc.
* A lastError property, mostly to control the `currentStatus` property which shows the error symbol

I was able to update and run the gdata provider `main` branch with these changes and was able to remove a few TODOs.