### PR TITLE
Fix schema mismatch: Use "CalendarItemFormats" (plural) in calendar-items.json

### DIFF
--- a/calendar/experiments/calendar/schema/calendar-items.json
+++ b/calendar/experiments/calendar/schema/calendar-items.json
@@ -11,7 +11,7 @@
           "calendarId": { "type": "string" },
           "type": { "type": "string", "enum": ["event", "task"] },
           "instance": { "type": "string", "optional": true },
-          "format": { "$ref": "CalendarItemFormat", "optional": true },
+          "format": { "$ref": "CalendarItemFormats", "optional": true },
           "item": { "$ref": "RawCalendarItem" },
           "metadata": { "type": "object", "additionalProperties": { "type": "any" }, "optional": true }
         }
@@ -120,7 +120,7 @@
             "name": "updateProperties",
             "type": "object",
             "properties": {
-              "format": { "$ref": "CalendarItemFormat", "optional": true },
+              "format": { "$ref": "CalendarItemFormats", "optional": true },
               "item": { "$ref": "RawCalendarItem" },
               "returnFormat": { "$ref": "ReturnFormat", "optional": true },
               "metadata": { "type": "object", "additionalProperties": { "type": "any" }, "optional": true }


### PR DESCRIPTION
### Description:
This PR fixes a schema inconsistency in web-experiments in `calendar-items.json` where the code expects `CalendarItemFormat` (singular), but the schema defines it as `CalendarItemFormats` (plural).

### Issue
- The mismatch causes errors when the code attempts to reference `CalendarItemFormat`, leading to failures. For example, if one uses the following valid update call:
```javascript
browser.calendar.items.update(eventItem.calendarId, eventItem.id, {
    format: "jcal",
    item: comp.toJSON()
});
```
despite all parameters being correct, this results in a `DOMException` / `InvalidStateError`.
- The correct name in the schema is `CalendarItemFormats` (plural), which aligns with the definition of the enum `CalendarItemFormats`.

### Fix
Updated references in `calendar-items.json` to use `CalendarItemFormats` consistently.