### PR TITLE
Replace cal.createAdapter-based calendar observers with explicit calIObserver objects

### DIFF
--- a/calendar/experiments/calendar/ext-calendar-utils.sys.mjs
+++ b/calendar/experiments/calendar/ext-calendar-utils.sys.mjs
@@ -239,6 +239,29 @@ export function convertAlarm(item, alarm) {
   };
 }
 
+/**
+ * Thunderbird >=148 no longer exposes cal.createAdapter(). Build explicit
+ * calIObserver objects so the calendar experiment keeps working on newer
+ * release channels as well as ESR.
+ *
+ * @param {object} methods
+ * @returns {calIObserver}
+ */
+export function createCalendarObserver(methods = {}) {
+  return Object.assign({
+    QueryInterface: ChromeUtils.generateQI(["calIObserver"]),
+    onStartBatch() {},
+    onEndBatch() {},
+    onLoad() {},
+    onAddItem() {},
+    onModifyItem() {},
+    onDeleteItem() {},
+    onError() {},
+    onPropertyChanged() {},
+    onPropertyDeleting() {},
+  }, methods);
+}
+
 export async function setupE10sBrowser(extension, browser, parent, initOptions={}) {
   browser.setAttribute("type", "content");
   browser.setAttribute("disableglobalhistory", "true");

--- a/calendar/experiments/calendar/parent/ext-calendar-calendars.js
+++ b/calendar/experiments/calendar/parent/ext-calendar-calendars.js
@@ -8,12 +8,12 @@ var { ExtensionUtils: { ExtensionError } } = ChromeUtils.importESModule("resourc
 var { cal } = ChromeUtils.importESModule("resource:///modules/calendar/calUtils.sys.mjs");
 
 /**
- * Thunderbird 149 no longer exposes cal.createAdapter(). Build explicit
+ * Thunderbird >=148 no longer exposes cal.createAdapter(). Build explicit
  * calIObserver objects so the vendored calendar experiment keeps working on
  * newer release channels as well as ESR.
  *
  * @param {object} methods
- * @returns {object}
+ * @returns {calIObserver}
  */
 function createCalendarObserver(methods = {}) {
   return Object.assign({

--- a/calendar/experiments/calendar/parent/ext-calendar-calendars.js
+++ b/calendar/experiments/calendar/parent/ext-calendar-calendars.js
@@ -7,35 +7,13 @@ var { ExtensionUtils: { ExtensionError } } = ChromeUtils.importESModule("resourc
 
 var { cal } = ChromeUtils.importESModule("resource:///modules/calendar/calUtils.sys.mjs");
 
-/**
- * Thunderbird >=148 no longer exposes cal.createAdapter(). Build explicit
- * calIObserver objects so the vendored calendar experiment keeps working on
- * newer release channels as well as ESR.
- *
- * @param {object} methods
- * @returns {calIObserver}
- */
-function createCalendarObserver(methods = {}) {
-  return Object.assign({
-    QueryInterface: ChromeUtils.generateQI(["calIObserver"]),
-    onStartBatch() {},
-    onEndBatch() {},
-    onLoad() {},
-    onAddItem() {},
-    onModifyItem() {},
-    onDeleteItem() {},
-    onError() {},
-    onPropertyChanged() {},
-    onPropertyDeleting() {},
-  }, methods);
-}
-
 this.calendar_calendars = class extends ExtensionAPI {
   getAPI(context) {
     const uuid = context.extension.uuid;
     const root = `experiments-calendar-${uuid}`;
     const query = context.extension.manifest.version;
     const {
+      createCalendarObserver,
       unwrapCalendar,
       getResolvedCalendarById,
       isOwnCalendar,

--- a/calendar/experiments/calendar/parent/ext-calendar-calendars.js
+++ b/calendar/experiments/calendar/parent/ext-calendar-calendars.js
@@ -7,6 +7,29 @@ var { ExtensionUtils: { ExtensionError } } = ChromeUtils.importESModule("resourc
 
 var { cal } = ChromeUtils.importESModule("resource:///modules/calendar/calUtils.sys.mjs");
 
+/**
+ * Thunderbird 149 no longer exposes cal.createAdapter(). Build explicit
+ * calIObserver objects so the vendored calendar experiment keeps working on
+ * newer release channels as well as ESR.
+ *
+ * @param {object} methods
+ * @returns {object}
+ */
+function createCalendarObserver(methods = {}) {
+  return Object.assign({
+    QueryInterface: ChromeUtils.generateQI(["calIObserver"]),
+    onStartBatch() {},
+    onEndBatch() {},
+    onLoad() {},
+    onAddItem() {},
+    onModifyItem() {},
+    onDeleteItem() {},
+    onError() {},
+    onPropertyChanged() {},
+    onPropertyDeleting() {},
+  }, methods);
+}
+
 this.calendar_calendars = class extends ExtensionAPI {
   getAPI(context) {
     const uuid = context.extension.uuid;
@@ -275,7 +298,7 @@ this.calendar_calendars = class extends ExtensionAPI {
             context,
             name: "calendar.calendars.onUpdated",
             register: fire => {
-              const observer = cal.createAdapter(Ci.calIObserver, {
+              const observer = createCalendarObserver({
                 onPropertyChanged(calendar, name, value, _oldValue) {
                   const converted = convertCalendar(context.extension, calendar);
                   switch (name) {

--- a/calendar/experiments/calendar/parent/ext-calendar-items.js
+++ b/calendar/experiments/calendar/parent/ext-calendar-items.js
@@ -8,12 +8,12 @@ var { ExtensionUtils: { ExtensionError } } = ChromeUtils.importESModule("resourc
 var { cal } = ChromeUtils.importESModule("resource:///modules/calendar/calUtils.sys.mjs");
 
 /**
- * Thunderbird 149 no longer exposes cal.createAdapter(). Build explicit
+ * Thunderbird >=148 no longer exposes cal.createAdapter(). Build explicit
  * calIObserver objects so the vendored calendar experiment keeps working on
  * newer release channels as well as ESR.
  *
  * @param {object} methods
- * @returns {object}
+ * @returns {calIObserver}
  */
 function createCalendarObserver(methods = {}) {
   return Object.assign({

--- a/calendar/experiments/calendar/parent/ext-calendar-items.js
+++ b/calendar/experiments/calendar/parent/ext-calendar-items.js
@@ -7,35 +7,13 @@ var { ExtensionUtils: { ExtensionError } } = ChromeUtils.importESModule("resourc
 
 var { cal } = ChromeUtils.importESModule("resource:///modules/calendar/calUtils.sys.mjs");
 
-/**
- * Thunderbird >=148 no longer exposes cal.createAdapter(). Build explicit
- * calIObserver objects so the vendored calendar experiment keeps working on
- * newer release channels as well as ESR.
- *
- * @param {object} methods
- * @returns {calIObserver}
- */
-function createCalendarObserver(methods = {}) {
-  return Object.assign({
-    QueryInterface: ChromeUtils.generateQI(["calIObserver"]),
-    onStartBatch() {},
-    onEndBatch() {},
-    onLoad() {},
-    onAddItem() {},
-    onModifyItem() {},
-    onDeleteItem() {},
-    onError() {},
-    onPropertyChanged() {},
-    onPropertyDeleting() {},
-  }, methods);
-}
-
 this.calendar_items = class extends ExtensionAPI {
   getAPI(context) {
     const uuid = context.extension.uuid;
     const root = `experiments-calendar-${uuid}`;
     const query = context.extension.manifest.version;
     const {
+      createCalendarObserver,
       getResolvedCalendarById,
       getCachedCalendar,
       isCachedCalendar,

--- a/calendar/experiments/calendar/parent/ext-calendar-items.js
+++ b/calendar/experiments/calendar/parent/ext-calendar-items.js
@@ -7,6 +7,29 @@ var { ExtensionUtils: { ExtensionError } } = ChromeUtils.importESModule("resourc
 
 var { cal } = ChromeUtils.importESModule("resource:///modules/calendar/calUtils.sys.mjs");
 
+/**
+ * Thunderbird 149 no longer exposes cal.createAdapter(). Build explicit
+ * calIObserver objects so the vendored calendar experiment keeps working on
+ * newer release channels as well as ESR.
+ *
+ * @param {object} methods
+ * @returns {object}
+ */
+function createCalendarObserver(methods = {}) {
+  return Object.assign({
+    QueryInterface: ChromeUtils.generateQI(["calIObserver"]),
+    onStartBatch() {},
+    onEndBatch() {},
+    onLoad() {},
+    onAddItem() {},
+    onModifyItem() {},
+    onDeleteItem() {},
+    onError() {},
+    onPropertyChanged() {},
+    onPropertyDeleting() {},
+  }, methods);
+}
+
 this.calendar_items = class extends ExtensionAPI {
   getAPI(context) {
     const uuid = context.extension.uuid;
@@ -164,7 +187,7 @@ this.calendar_items = class extends ExtensionAPI {
             context,
             name: "calendar.items.onCreated",
             register: (fire, options) => {
-              const observer = cal.createAdapter(Ci.calIObserver, {
+              const observer = createCalendarObserver({
                 onAddItem: item => {
                   fire.sync(convertItem(item, options, context.extension));
                 },
@@ -181,7 +204,7 @@ this.calendar_items = class extends ExtensionAPI {
             context,
             name: "calendar.items.onUpdated",
             register: (fire, options) => {
-              const observer = cal.createAdapter(Ci.calIObserver, {
+              const observer = createCalendarObserver({
                 onModifyItem: (newItem, _oldItem) => {
                   // TODO calculate changeInfo
                   const changeInfo = {};
@@ -200,7 +223,7 @@ this.calendar_items = class extends ExtensionAPI {
             context,
             name: "calendar.items.onRemoved",
             register: fire => {
-              const observer = cal.createAdapter(Ci.calIObserver, {
+              const observer = createCalendarObserver({
                 onDeleteItem: item => {
                   fire.sync(item.calendar.id, item.id);
                 },


### PR DESCRIPTION
Fixes #66

## Summary

This PR replaces `cal.createAdapter(Ci.calIObserver, ...)` usage in the calendar experiment with explicit `calIObserver` objects using:

```js
QueryInterface: ChromeUtils.generateQI(["calIObserver"])
```

## Problem

On newer Thunderbird releases, `cal.createAdapter` is no longer available.

That breaks listener registration in the calendar experiment and prevents these experiment events from being registered correctly:

- `calendar.items.onCreated`
- `calendar.items.onUpdated`
- `calendar.items.onRemoved`
- `calendar.calendars.onUpdated`

## Cause

The experiment currently relies on:

```js
cal.createAdapter(Ci.calIObserver, { ... })
```

for internal observer creation.

When that helper is unavailable, observer registration fails before `cal.manager.addCalendarObserver(observer)` can succeed.

## Fix

Replace the removed helper usage with explicit `calIObserver` objects.

The patch adds small local helpers which provide:

- `QueryInterface: ChromeUtils.generateQI(["calIObserver"])`
- no-op implementations for unused observer callbacks
- only the event-specific methods overridden where needed

This keeps the public experiment API unchanged and only updates internal observer construction.

## Affected files

- `calendar/experiments/calendar/parent/ext-calendar-items.js`
- `calendar/experiments/calendar/parent/ext-calendar-calendars.js`

## Verification

Verified manually on:

- Thunderbird ESR 140
- Thunderbird Release 149

After the patch:
- `calendar.items.onCreated` works
- `calendar.items.onUpdated` works
- `calendar.items.onRemoved` works
- `calendar.calendars.onUpdated` works
- the previous `cal.createAdapter is not a function` runtime errors are gone

## Notes

This is a compatibility fix only.
It does not change the public experiment API surface or semantics.